### PR TITLE
Add NJ historical map service and add all layers it supports

### DIFF
--- a/src/app/components/arc-map/arc-map.component.ts
+++ b/src/app/components/arc-map/arc-map.component.ts
@@ -15,6 +15,8 @@ import FeatureLayer from '@arcgis/core/layers/FeatureLayer';
 import View from "@arcgis/core/views/View";
 import LayerView from "@arcgis/core/views/layers/LayerView";
 import { whenOnce } from '@arcgis/core/core/reactiveUtils';
+import { NjHistoricalMapsService, NjHistoricalMapType } from '../../services/nj-historical-maps.service';
+import Layer from '@arcgis/core/layers/Layer';
 
 @Component({
   selector: 'app-arc-map',
@@ -38,6 +40,7 @@ export class ArcMapComponent implements OnInit {
     );
   constructor(private protectedAreasService: ProtectedAreasService,
     private unprotectedAreasService: UnprotectedAreasService,
+    private njHistoricalMapsService: NjHistoricalMapsService,
     private progressService: ProgressService
   ) { }
 
@@ -52,6 +55,15 @@ export class ArcMapComponent implements OnInit {
     this.unprotectedAreasService.initializePopup(view);
     map.add(protectedAreasLayer);
     this.protectedAreasService.initializePopup(view);
+
+    // add the NJ Historical Maps, but they won't be visible by default
+    const mapTypes = Object.values(NjHistoricalMapType);
+    mapTypes.forEach((mapType) => {
+      const historicalLayer: Layer | undefined = this.njHistoricalMapsService.createLayer(<NjHistoricalMapType>mapType);
+      if (historicalLayer) {
+        map.add(historicalLayer);
+      }
+    });
 
     this.waitForLayersToLoad(view, unprotectedAreasLayer, protectedAreasLayer);
   }

--- a/src/app/services/nj-historical-maps.service.spec.ts
+++ b/src/app/services/nj-historical-maps.service.spec.ts
@@ -1,0 +1,16 @@
+import { TestBed } from '@angular/core/testing';
+
+import { NjHistoricalMapsService } from './nj-historical-maps.service';
+
+describe('NjHistoricalMapsService', () => {
+  let service: NjHistoricalMapsService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(NjHistoricalMapsService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+});

--- a/src/app/services/nj-historical-maps.service.ts
+++ b/src/app/services/nj-historical-maps.service.ts
@@ -1,0 +1,115 @@
+import { Injectable } from '@angular/core';
+import FeatureLayer from '@arcgis/core/layers/FeatureLayer';
+import Layer from '@arcgis/core/layers/Layer';
+import WMSLayer from '@arcgis/core/layers/WMSLayer';
+
+export enum NjHistoricalMapType {
+  HistoricalMaps1881to1924,
+  LandCover2007,
+  LandCover2020,
+  UsgsTopo100k,
+  WetlandsFromLandCover2002,
+  WetlandsImagery1970,
+  AerialImagery1930,
+}
+export enum LayerType {
+  WMSLayer,
+  ImageryTileLayer,
+  FeatureLayer
+}
+
+export interface NjHistoricalMap {
+  type: NjHistoricalMapType;
+  title: string;
+  url: string;
+  layerType: LayerType;
+  sublayer?: string;
+}
+
+@Injectable({
+  providedIn: 'root'
+})
+// service to make it easy to add a variety of NJ historical map layers to the map
+export class NjHistoricalMapsService {
+  defaultOpacity: number = 0.4;
+  defaultVisibility: boolean = false;
+
+  availableMaps: NjHistoricalMap[] = [
+    {
+      type: NjHistoricalMapType.HistoricalMaps1881to1924,
+      title: "NJ Historical Maps (1881-1924)",
+      url: "https://img.nj.gov/imagerywms/HistoricalMaps",
+      layerType: LayerType.WMSLayer
+    },
+    {
+      type: NjHistoricalMapType.LandCover2007,
+      title: "NJ Land Cover (2007)",
+      url: "https://mapsdep.nj.gov/arcgis/rest/services/Features/Land_lu/MapServer/4",
+      layerType: LayerType.FeatureLayer,
+    },
+    {
+      type: NjHistoricalMapType.LandCover2020,
+      title: "NJ Land Cover (2020)",
+      url: "https://services1.arcgis.com/QWdNfRs7lkPq4g4Q/arcgis/rest/services/Land_Use_2020/FeatureServer/5",
+      layerType: LayerType.FeatureLayer,
+    },
+    {
+      type: NjHistoricalMapType.UsgsTopo100k,
+      title: "USGS Topo 100k",
+      url: "https://img.nj.gov/imagerywms/Topo100K",
+      layerType: LayerType.WMSLayer
+    },
+    {
+      type: NjHistoricalMapType.WetlandsFromLandCover2002,
+      title: "Wetlands from Land Cover (2002)",
+      url: "https://mapsdep.nj.gov/arcgis/rest/services/Features/Land_lu/MapServer/9",
+      layerType: LayerType.FeatureLayer,
+    },
+    {
+      type: NjHistoricalMapType.WetlandsImagery1970,
+      title: "Wetlands Imagery (1970)",
+      url: "https://img.nj.gov/imagerywms/Wetlands1970",
+      layerType: LayerType.WMSLayer,
+    },
+    {
+      type: NjHistoricalMapType.AerialImagery1930,
+      title: "Aerial Imagery (1930)",
+      url: "https://img.nj.gov/imagerywms/BlackWhite1930",
+      layerType: LayerType.WMSLayer
+    }
+  ];
+  constructor() { }
+
+  createLayer(mapType: NjHistoricalMapType): Layer | undefined {
+    const njHistoricalMap = this.availableMaps.find(m => m.type === mapType);
+    if (!njHistoricalMap) {
+      return undefined;
+    }
+    switch (njHistoricalMap.layerType) {
+      case LayerType.WMSLayer:
+        return this.createWmsLayer(njHistoricalMap);
+      case LayerType.FeatureLayer:
+        return this.createFeatureLayer(njHistoricalMap);
+      default:
+        return undefined;
+    }
+  }
+  createWmsLayer(njHistoricalMap: NjHistoricalMap): WMSLayer {
+    let wmsLayer: WMSLayer = new WMSLayer({
+      url: njHistoricalMap.url,
+      title: njHistoricalMap.title,
+      opacity: this.defaultOpacity,
+      visible: this.defaultVisibility,
+    });
+    return wmsLayer;
+  }
+  createFeatureLayer(njHistoricalMap: NjHistoricalMap): FeatureLayer {
+    let featureLayer: FeatureLayer = new FeatureLayer({
+      url: njHistoricalMap.url,
+      title: njHistoricalMap.title,
+      opacity: this.defaultOpacity,
+      visible: this.defaultVisibility,
+    });
+    return featureLayer;
+  }
+}


### PR DESCRIPTION
to the map by defaul, but don't display initially.  For now user can make them visible using the layer control.